### PR TITLE
Fix-errors-readinessProbe-livenessProbe-sintax 

### DIFF
--- a/charts/public-service/templates/deployment.yaml
+++ b/charts/public-service/templates/deployment.yaml
@@ -66,10 +66,14 @@ spec:
                   name: {{ $chartName }}-secret
                   key: {{ $key }}
         {{- end}}
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-{{ toYaml .Values.livenessProbe | indent 10 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-{{ toYaml .Values.readinessProbe | indent 10 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.startupProbe }}
           startupProbe:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
Make liveness and readiness probes optional using conditional blocks in deployment template

So after some testing, I figured out that the old Suntax block corrects config parsing 

<img width="1101" height="829" alt="image" src="https://github.com/user-attachments/assets/c075d3ee-50b6-43df-afef-8980b2624d89" />
